### PR TITLE
Avoid restarting unbound whenever a dhcpd lease changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 ## dhcpd_unbound_bridge
 awk script to parse DHCP leases handed out by the ISC DHCP server and parse them into a format readable by unbound. Original written by @davidbarnhart, adapter by @robdejonge to use explicit hostnames, and updated by @cniesen to load and update dns records without restarting unbound.
 
-After unbound is started/restarted via rccl, the load_dhcp_lease_entries.sh script is run to perform the initial load of the addresses of active leases. 
-
 ### How to install (suggested):
 
 1. Place the dhcpd-lease-parser.awk script somewhere like /usr/local/sbin and make sure it's executable (chmod 755)
 2. Place the load_dhcp_lease_entries.sh script in the same directory as the unbound configuration files (e.g. /usr/local/etc/unbound/) and make sure it's also executable.  Verify the INPUTFILE, OUTPUTFILE, DOMAIN, TTL, and MAPPINGSFILE properties are correctly set in the script.
 3. (optional) Enter your mappings into the mappings.db file (which is just a text file) in a `MA:CA:DD:RE:SS myhostname` format (note the space).
 4. Ensure that unbound configuration file (e.g. /usr/local/etc/unbound/unbound.conf) has `remote-control: control-enable: yes` and that the unbound-control command works.
-5. Update the `/etc/rc.d/unbound` file to run the load_dhcp_lease_entries.sh script after start.
+5. Add a cron job for root to execute the bash script every five minutes, which refreshes the parsed leases files and reloads unbound: */5 * * * * root /usr/local/etc/unbound/load_dhcp_lease_entries.sh
+6. Optional, update the `/etc/rc.d/unbound` file to run the load_dhcp_lease_entries.sh script right after start.
 ```
 #!/bin/ksh
 #
@@ -42,7 +41,7 @@ rc_cmd $1
 ```
 
 Note that an alternative to the cron job would be to leverage the ISC DHCP server's ability to execute a command each time a lease is handed out: https://jpmens.net/2011/07/06/execute-a-script-when-isc-dhcp-hands-out-a-new-lease/ 
-For OpenBSD however, this is not an option since this feature isn't availiable with the default dhcpd server.
+OpenBSD's dhcpd implementation is leaner and does not have these features.
 
 
 ### Background by @davidbarnhart
@@ -59,3 +58,9 @@ The awk script does the majority of the work, trying to parse valid leases (thro
 ### Modification by @robdejonge
 
 Instead of using the `client-hostname` directive from the `dhcpd.leases` file, I needed a way to use explicit hostnames so that whatever each host tells `dhcpd` can be ignored and entries in `unbound` are the way I want them to be. Some devices can't be configured to use a sensible hostname, and the non-sensical ones can be hard to recall! The script will now search `mappings.db` for a match (that part admittedly an ugly hack!), and if one is found use that as the overriding hostname for the output. 
+
+### Modification by @cniesen
+
+My main motivation was to avoid restarting unbound whenever a dhcpd lease changed.  I solved this by using unbound-control to add and remove the dhcpd records while unbound is running. The script will only add/remove changes that occurred since last run. If the cron delay for the initial load after the server start is unacceptable then add the `/etc/rc.d/unbound` modification to run the dhcpd load whenever unbound is started or restarted.
+
+I had to do a few minor tweaks to support server names without domains and to get reverse lookups working.  I've added logging as well.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,48 @@
 ## dhcpd_unbound_bridge
-awk script to parse DHCP leases handed out by the ISC DHCP server and parse them into a format readable by unbound. Original written by @davidbarnhart, adapter by @robdejonge to use explicit hostnames. 
+awk script to parse DHCP leases handed out by the ISC DHCP server and parse them into a format readable by unbound. Original written by @davidbarnhart, adapter by @robdejonge to use explicit hostnames, and updated by @cniesen to load and update dns records without restarting unbound.
+
+After unbound is started/restarted via rccl, the load_dhcp_lease_entries.sh script is run to perform the initial load of the addresses of active leases. 
 
 ### How to install (suggested):
 
 1. Place the dhcpd-lease-parser.awk script somewhere like /usr/local/sbin and make sure it's executable (chmod 755)
-2. Place the load_dhcp_lease_entries.sh script in the same directory as the unbound configuration files (e.g. /usr/local/etc/unbound/) and make sure it's also executable.
+2. Place the load_dhcp_lease_entries.sh script in the same directory as the unbound configuration files (e.g. /usr/local/etc/unbound/) and make sure it's also executable.  Verify the INPUTFILE, OUTPUTFILE, DOMAIN, TTL, and MAPPINGSFILE properties are correctly set in the script.
 3. (optional) Enter your mappings into the mappings.db file (which is just a text file) in a `MA:CA:DD:RE:SS myhostname` format (note the space).
-4. Edit the unbound configuration file (e.g. /usr/local/etc/unbound/unbound.conf) and add an include line to the parsed file that is created by the load_dhcp_lease_entries.sh script (e.g. `include "/usr/local/etc/unbound/dhcp_lease_entries.conf"`)
-5. Add a cron job for root to execute the bash script every five minutes, which refreshes the parsed leases files and reloads unbound: */5	*	*	*	*	root	/usr/local/etc/unbound/load_dhcp_lease_entries.sh
+4. Ensure that unbound configuration file (e.g. /usr/local/etc/unbound/unbound.conf) has `remote-control: control-enable: yes` and that the unbound-control command works.
+5. Update the `/etc/rc.d/unbound` file to run the load_dhcp_lease_entries.sh script after start.
+```
+#!/bin/ksh
+#
+# $OpenBSD: unbound,v 1.9 2024/10/09 15:42:56 kn Exp $
 
-Note that an alternative to the cron job would be to leverage the ISC DHCP server's ability to execute a command each time a lease is handed out: https://jpmens.net/2011/07/06/execute-a-script-when-isc-dhcp-hands-out-a-new-lease/
+daemon="/usr/sbin/unbound"
+daemon_flags="-c /var/unbound/etc/unbound.conf"
+
+. /etc/rc.d/rc.subr
+
+rc_pre() {
+        local _anchor=$(/usr/sbin/unbound-checkconf -o auto-trust-anchor-file)
+
+        if [[ -n $_anchor && ! -f $_anchor ]]; then
+                /usr/sbin/unbound-anchor -v
+        fi
+
+        /usr/sbin/unbound-checkconf
+}
+
+rc_start() {
+        ${rcexec} ${daemon} ${daemon_flags} ${_bg}
+
+        if [ $? -eq 0 ]; then
+                /var/dhcpd_unbound_bridge/load_dhcp_lease_entries.sh
+        fi
+}
+
+rc_cmd $1
+```
+
+Note that an alternative to the cron job would be to leverage the ISC DHCP server's ability to execute a command each time a lease is handed out: https://jpmens.net/2011/07/06/execute-a-script-when-isc-dhcp-hands-out-a-new-lease/ 
+For OpenBSD however, this is not an option since this feature isn't availiable with the default dhcpd server.
 
 
 ### Background by @davidbarnhart

--- a/dhcpd-lease-parser.awk
+++ b/dhcpd-lease-parser.awk
@@ -3,40 +3,41 @@
 BEGIN {
 
 	# settings
-	optionaldomain = DOMAIN; # optional domain name. this should get fed to the script as a parameter
+	domain = DOMAIN; # domain name. this should get fed to the script as a parameter. needs to end with a period
+	ttl = TTL; # ttl of dns record. this should get fed to the script as a parameter.
 	output_human = 0;    # set to 1 to output human-readable lease information
-	output_record = 1;   # set to 1 to output A records 
+	output_record = 1;   # set to 1 to output A records
 	output_ptr = 1;      # set to 1 to output PTR records
 }
 
 END {
 
-	if (output_human == 1) { 
-		for (macaddress in ipaddress_array) 
+	if (output_human == 1) {
+		for (macaddress in ipaddress_array)
 			printf  "# mac " macaddress ", " \
 				"host " hostname_array[macaddress] ", " \
 				"ip " ipaddress_array[macaddress] ", " \
 				timeleft_array[macaddress] " seconds left on the lease" \
 				"\n";
 	}
-		
-	if (output_record == 1) { 
-		for (macaddress in ipaddress_array)
-			printf  "local-data: \"" \
-				hostname_array[macaddress]optionaldomain \
-				" IN A " \
-				ipaddress_array[macaddress] "\"" \
-				"\n";
-	} 
 
-	if (output_ptr == 1) { 
+	if (output_record == 1) {
 		for (macaddress in ipaddress_array)
-			printf  "local-data-ptr: \"" \
-				ipaddress_array[macaddress] \
-				" " \
-				hostname_array[macaddress]optionaldomain "\"" \
+			printf  hostname_array[macaddress]domain " " \
+				ttl " IN A " \
+				ipaddress_array[macaddress]  \
 				"\n";
-	} 
+		}
+
+	if (output_ptr == 1) {
+		for (macaddress in ipaddress_array) {
+			split(ipaddress_array[macaddress], octets, ".");
+			printf  octets[4] "." octets[3] "." octets[2] "." octets[1] ".in-addr.arpa. " \
+				ttl " IN PTR " \
+				hostname_array[macaddress]domain  \
+				"\n";
+		}
+	}
 
 }
 
@@ -48,7 +49,7 @@ END {
 	declared_hostname = "";
 	fallback_hostname = "";
 	hostname = "";
-	macaddress = "";	
+	macaddress = "";
 
 	ipaddress = $2;
 }
@@ -65,7 +66,7 @@ END {
 	# put the lease end date into the format of epoch (in seconds)
 	# using the epoch makes it easier to perform date comparisons
 	"date -j -f \"%Y\/%m\/%d%H:%M:%S\" \"" $1 $2 "\" +%s" | getline enddate # FreeBSD version
-	
+
 	# do the same for the current date/time
 	#"date -j +%s" | getline currentdate # FreeBSD version
 	"date +%s" | getline currentdate
@@ -76,8 +77,8 @@ END {
 }
 
 /hardware ethernet/ {
-        gsub(/;/,"");
-        macaddress = $3;
+	gsub(/;/,"");
+	macaddress = $3;
 	gsub(/:/,"");
 	fallback_hostname = $3;
 }
@@ -102,18 +103,18 @@ END {
 		close(lookup_command)
 
 		if (length(mapped_hostname) == 0) {
-				hostname = declared_hostname;
+			hostname = declared_hostname;
 		} else {
-				hostname = mapped_hostname;
+			hostname = mapped_hostname;
 		}
 
 		if (length(hostname) == 0) {
 			hostname = fallback_hostname;
 		}
-		
+
 		# Then we need to check to see whether it's actually the latest lease or not.
 		# If a lease exists with a newer/greater enddate, then this lease should be ignored.
-		
+
 		if (macaddress in ipaddress_array) {
 			# we already have a lease recorded for this hostname
 			# check the lease enddate to see if this lease is newer than the one we had previously recorded
@@ -133,4 +134,3 @@ END {
 		}
 	}
 }
-

--- a/load_dhcp_lease_entries.sh
+++ b/load_dhcp_lease_entries.sh
@@ -1,24 +1,18 @@
 #!/bin/sh
 
-# This script works in tandem with the "dhcpd-lease-parser.awk" script to translate the DHCP lease info from the "dhcpd" service into a form that is friendly for the "unbound" service. The aim is to detect new leases issued by "dhcpd" and then update "unbound" so that it can resolve the IP addresses issued by "dhcpd" to the appropriate hostnames.
+# This script works in tandem with the "dhcpd-lease-parser.awk" script to translate the DHCP lease info from the "dhcpd" service into a form that is friendly for "unbound-control local_datas" command.
+# The aim is to load the dynamic dhcp addresses after a fresh "unbound" server (re)start so that it can resolve the IP addresses issued by "dhcpd" to the appropriate hostnames.
 
 INPUTFILE="/var/db/dhcpd.leases" # this is the default FreeBSD DHCP leases file
 OUTPUTFILE="/usr/local/etc/unbound/dhcp_lease_entries.conf" # location to store the DHCP lease information so that unbound can use it
-DOMAIN="" # takes the form ".domain", otherwise leave blank if not using a domain
+DOMAIN="." # takes the form ".domain", use "." if not using a domain
+TTL="600" #TTL of the DNS records
 MAPPINGSFILE="/usr/local/etc/unbound/mappings.db" # an optional file. allows mapping MAC addresses to specific hostnames
 
 # create the following files if they don't already exist:
 test -f $OUTPUTFILE || touch $OUTPUTFILE # just in case this is the very first time and the file doesn't exist yet (to avoid the "stat" command below from throwing an error)
 test -f $MAPPINGSFILE || touch $MAPPINGSFILE
 
-# get various file metadata properties (helps to detect whether it's time to parse the leases yet)
-INPUTFILE_LASTMODIFIED=$(stat -f %m $INPUTFILE) 
-OUTPUTFILE_LASTMODIFIED=$(stat -f %m $OUTPUTFILE) 
-MAPPINGSFILE_LASTMODIFIED=$(stat -f %m $MAPPINGSFILE)
-OUTPUTFILE_SIZE=$(stat -f %z $OUTPUTFILE)
 
-# if something recently changes, regenerate the "unbound" leases file and force "unbound" to reload the list
-if [ $INPUTFILE_LASTMODIFIED -gt $OUTPUTFILE_LASTMODIFIED ] || [ $MAPPINGSFILE_LASTMODIFIED -gt $OUTPUTFILE_LASTMODIFIED ] || [ $OUTPUTFILE_SIZE -eq 0 ]; then 
-	dhcpd-lease-parser.awk -v DOMAIN=$DOMAIN -v MAPPINGSFILE=$MAPPINGSFILE $INPUTFILE | uniq -u > $OUTPUTFILE
-	service unbound reload
-fi 
+./dhcpd-lease-parser.awk -v DOMAIN=$DOMAIN -v TTL=$TTL -v MAPPINGSFILE=$MAPPINGSFILE $INPUTFILE | uniq -u > $OUTPUTFILE
+unbound-control local_datas < $OUTPUTFILE

--- a/load_dhcp_lease_entries.sh
+++ b/load_dhcp_lease_entries.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-# This script works in tandem with the "dhcpd-lease-parser.awk" script to translate the DHCP lease info from the "dhcpd" service into a form that is friendly for "unbound-control local_datas" command.
-# The aim is to load the dynamic dhcp addresses after a fresh "unbound" server (re)start so that it can resolve the IP addresses issued by "dhcpd" to the appropriate hostnames.
+# This script works in tandem with the "dhcpd-lease-parser.awk" script to translate the DHCP lease info from the "dhcpd" service into a form that is friendly for the "unbound" service. The aim is to detect new leases issued by "dhcpd" and then update "unbound" so that it can resolve the IP addresses issued by "dhcpd" to the appropriate hostnames.
 
 INPUTFILE="/var/db/dhcpd.leases" # this is the default FreeBSD DHCP leases file
 OUTPUTFILE="/usr/local/etc/unbound/dhcp_lease_entries.conf" # location to store the DHCP lease information so that unbound can use it
@@ -13,6 +12,41 @@ MAPPINGSFILE="/usr/local/etc/unbound/mappings.db" # an optional file. allows map
 test -f $OUTPUTFILE || touch $OUTPUTFILE # just in case this is the very first time and the file doesn't exist yet (to avoid the "stat" command below from throwing an error)
 test -f $MAPPINGSFILE || touch $MAPPINGSFILE
 
+# get various file metadata properties (helps to detect whether it's time to parse the leases yet)
+INPUTFILE_LASTMODIFIED=$(stat -f %m $INPUTFILE) 
+OUTPUTFILE_LASTMODIFIED=$(stat -f %m $OUTPUTFILE) 
+MAPPINGSFILE_LASTMODIFIED=$(stat -f %m $MAPPINGSFILE)
+OUTPUTFILE_SIZE=$(stat -f %z $OUTPUTFILE)
 
-./dhcpd-lease-parser.awk -v DOMAIN=$DOMAIN -v TTL=$TTL -v MAPPINGSFILE=$MAPPINGSFILE $INPUTFILE | uniq -u > $OUTPUTFILE
-unbound-control local_datas < $OUTPUTFILE
+# if something recently changes, regenerate the "unbound" leases file and update "unbound" as needed
+if [ $INPUTFILE_LASTMODIFIED -gt $OUTPUTFILE_LASTMODIFIED ] || [ $MAPPINGSFILE_LASTMODIFIED -gt $OUTPUTFILE_LASTMODIFIED ] || [ $OUTPUTFILE_SIZE -eq 0 ]; then 
+	# Create TEMPFILE from current dhcpd leases
+	TEMPFILE=$(mktemp /tmp/dhtpd_unbound_bridge.XXXXXX)
+	./dhcpd-lease-parser.awk -v DOMAIN=$DOMAIN -v TTL=$TTL -v MAPPINGSFILE=$MAPPINGSFILE $INPUTFILE | sort -u > $TEMPFILE
+	
+
+	# Find REMOVALS (Lines in OUTPUTFILE that are not in TEMPFILE)
+	comm -23 "$OUTPUTFILE" "$TEMPFILE" | while read -r name _ _ _ _; do
+		if [ -n "$name" ]; then
+			MSG=$(unbound-control local_data_remove "$name" 2>&1)
+			if [ -n "$MSG" ]; then
+				logger -t dhcp_unbound_bridge -p daemon.info "Remove $name: $MSG"
+			fi
+		fi
+	done
+
+	# Find ADDITIONS (Lines in TEMPFILE that are not in OUTPUTFILE)
+	comm -13 "$OUTPUTFILE" "$TEMPFILE" | while read -r raw_record; do
+		if [ -n "$raw_record" ]; then
+			MSG=$(unbound-control local_data "$raw_record" 2>&1)
+			if [ -n "$MSG" ]; then
+				logger -t dhcp_unbound_bridge -p daemon.info "Add record ($raw_record): $MSG"
+			fi
+		fi
+	done
+
+
+	# Update OUTPUTFILE and remove TEMPFILE
+	cat "$TEMPFILE" > "$OUTPUTFILE"
+	rm -f "$TEMPFILE"
+fi


### PR DESCRIPTION
My main motivation was to avoid restarting unbound whenever a dhcpd lease changed.  I solved this by using unbound-control to add and remove the dhcpd records while unbound is running. The script will only add/remove changes that occurred since last run. If the cron delay for the initial load after the server start is unacceptable then add the `/etc/rc.d/unbound` modification to run the dhcpd load whenever unbound is started or restarted.

I had to do a few minor tweaks to support server names without domains and to get reverse lookups working.  I've added logging as well.